### PR TITLE
Fix input handling from files

### DIFF
--- a/raspsim.cpp
+++ b/raspsim.cpp
@@ -792,8 +792,8 @@ int main(int argc, char** argv) {
 
       for (;;) {
         line.reset();
-        is >> line;
         if (!is) break;
+        is >> line;
 
         char* p = strchr(line, '#');
         if (p) *p = 0;


### PR DESCRIPTION
When taking input from a file the handler would first take a line and then check if the input stream was empty even though it might have just successfully pulled a line out of it.
This change moves the empty check before the read from the input stream to fix this behavior.