### PR TITLE
Fix incorrect operand decoding for setcc instructions

### DIFF
--- a/decode-fast.cpp
+++ b/decode-fast.cpp
@@ -742,7 +742,7 @@ bool TraceDecoder::decode_fast() {
 
   case 0x190 ... 0x19f: {
     // conditional sets
-    DECODE(eform, rd, v_mode);
+    DECODE(eform, rd, b_mode);
     EndOfDecode();
 
     int r;


### PR DESCRIPTION
When decoding conditional set instructions, the decoder uses an incorrect "bytemode" when decoding the operand which will cause it to use an incorrect lookup array when trying to parse register operands leading to `ah`,`bh`,`ch` and `dh` being decoded as `spl`,`dil`,`bpl`,`sil`. This commit changes the bytemode to the correct one and seems to now decode the correct operands for register and memory ops.